### PR TITLE
Enhance S3 client compatibility by removing x-amz-checksum-mode header

### DIFF
--- a/apps/web/src/core/s3/client.ts
+++ b/apps/web/src/core/s3/client.ts
@@ -25,7 +25,23 @@ function createS3Client(): S3Client {
     s3ClientConfig.endpoint = env.S3_ENDPOINT
   }
 
-  return new S3Client(s3ClientConfig)
+  const client = new S3Client(s3ClientConfig)
+
+  // 添加中间件以移除 x-amz-checksum-mode 请求头
+  client.middlewareStack.add(
+    (next) => async (args) => {
+      const request = args.request as { headers?: Record<string, string> }
+      if (request.headers) {
+        delete request.headers['x-amz-checksum-mode']
+      }
+      return next(args)
+    },
+    {
+      step: 'build',
+    },
+  )
+
+  return client
 }
 
 export const s3Client = createS3Client()


### PR DESCRIPTION
Add middleware to the S3 client to remove the `x-amz-checksum-mode` request header, improving compatibility with certain S3 configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with certain S3 operations by automatically removing the unsupported `x-amz-checksum-mode` header from outgoing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->