### PR TITLE
Remove x-amz-checksum-crc32 header for S3 client compatibility

### DIFF
--- a/apps/web/src/core/s3/client.ts
+++ b/apps/web/src/core/s3/client.ts
@@ -41,6 +41,20 @@ function createS3Client(): S3Client {
     },
   )
 
+  // 添加中间件以移除 x-amz-checksum-crc32 请求头
+  client.middlewareStack.add(
+    (next) => async (args) => {
+      const request = args.request as { headers?: Record<string, string> }
+      if (request.headers) {
+        delete request.headers['x-amz-checksum-crc32']
+      }
+      return next(args)
+    },
+    {
+      step: 'build',
+    },
+  )
+
   return client
 }
 


### PR DESCRIPTION
Add middleware to the S3 client to remove the x-amz-checksum-crc32 request header, enhancing compatibility with certain S3 services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of outgoing S3 requests by ensuring the `x-amz-checksum-crc32` header is removed, enhancing compatibility and preventing potential issues during file uploads or downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->